### PR TITLE
Fix URP additional light loop to use standard helpers

### DIFF
--- a/Assets/RealTimeLightBaker/Shaders/UVRuntimeBakerURP.shader
+++ b/Assets/RealTimeLightBaker/Shaders/UVRuntimeBakerURP.shader
@@ -106,13 +106,10 @@ Shader "Hidden/RealTimeLightBaker/UVRuntimeBakerURP"
                 lighting += ndotlMain * mainLight.color * mainLight.distanceAttenuation * mainLight.shadowAttenuation;
 
             #ifdef _ADDITIONAL_LIGHTS
-                uint additionalCount = GetAdditionalLightsCount();
-                [loop] for (uint li = 0u; li < additionalCount; ++li)
-                {
-                    Light lightData = GetAdditionalLight(li, input.positionWS);
-                    float ndotl = saturate(dot(N, lightData.direction));
-                    lighting += ndotl * lightData.color * lightData.distanceAttenuation * lightData.shadowAttenuation;
-                }
+                LIGHT_LOOP_BEGIN(input.positionWS)
+                    float ndotl = saturate(dot(N, light.direction));
+                    lighting += ndotl * light.color * light.distanceAttenuation * light.shadowAttenuation;
+                LIGHT_LOOP_END
             #endif
 
                 float3 baked = lighting;


### PR DESCRIPTION
## Summary
- replace the manual additional light loop with URP's LIGHT_LOOP helpers to pick the correct light indices
- ensure additional lights retrieve proper shadow attenuation for both Forward and Forward+ paths

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68e286f3fee08328bea5aaa0e7c8b2ec